### PR TITLE
added possibility to query Kobo API using name and not ID, #3

### DIFF
--- a/fetch_kobo_data.js
+++ b/fetch_kobo_data.js
@@ -1,34 +1,27 @@
 //== Job to be used for fetching data from Kobo on repeated, timer basis  ==//
 // This can be run on-demand at any time by clicking "run" //
 
-alterState(state => {
-  // Set a manual cursor if you'd like to only fetch data after this date.
+get('https://kf.kobotoolbox.org/api/v2/assets/?format=json', {}, state => {
+  // Set a manual cursor if you'd like to only fetch data 
   manualCursor = '2020-05-25T14:32:43.325+01:00';
-  state.data = {
-    surveys: [
-      { id: 'afCPRfan8JdBt9sy9q48Jp', tag: 'Rural Consumption' }, //Form Id, Tag of test OpenFN BNS Survey form --> For Testing
-      // Add more Form ids and tags to this list to perform more Kobo syncs...
-      //{ id: 'atyo55YdBdfxzXiaBdrbvr', tag: 'bns_2019' }, //BNS Price survey to be synced regularly
-      //{ id: 'aTRKQW2b8TJGxF7DVPfjFv', tag: 'bns_price_2019' }, //BNS Price survey to be synced regularly
-    ].map(survey => ({
-      formId: survey.id,
-      tag: survey.tag,
-      url: `https://kf.kobotoolbox.org/api/v2/assets/${survey.id}/data/?format=json`,
-      //query: `&query={"end":{"$gte":"${state.lastEnd || manualCursor}"}}`,
-    })),
-  };
+  state.data.forms = state.data.results
+    .filter(resource => resource.name.includes('Rural Consumption'))
+    .map(form => {
+      const url = form.url.split('?').join('data/?');
+      return {
+        formId: form.uid,
+        tag: 'Rural Consumption',
+        url,
+        query: `&query={"end":{"$gte":"${state.lastEnd || manualCursor}"}}`,
+      };
+    });
   return state;
 });
 
-alterState(state => {
-    console.log(state);
-
-    return state;
-})
-
-each(dataPath('surveys[*]'), state =>
-  //get(`${state.data.url}${state.data.query}`, {}, state => {
-  get(`${state.data.url}`, {}, state => {
+each(
+  dataPath('forms[*]'), state =>
+  get(`${state.data.url}${state.data.query}`, {}, state => {
+    console.log(state.data);
     state.data.submissions = state.data.results.map(submission => ({
       //Here we append the tags defined above to the Kobo form submission data
       form: lastReferenceValue('tag')(state),
@@ -52,7 +45,6 @@ each(dataPath('surveys[*]'), state =>
               }, delay);
             });
           }
-
           async function msg() {
             const msg = await timer();
             console.log(msg);

--- a/ruralConsumptionToPostgres.js
+++ b/ruralConsumptionToPostgres.js
@@ -2,7 +2,7 @@ upsert('tbl_study', 'study_id', {
   study_id: 1000,
 });
 
-upsert('tbl_site', 'site_id', {
+/*upsert('tbl_site', 'site_id', {
   site_id: 1001,
   admin_level_3: state.data['survey_info/district'],
   site_name: state.data['survey_info/village'],
@@ -13,9 +13,9 @@ upsert('tbl_household', 'external_id', {
   site_id: 1001,
   household_id: state.data['survey_info/household_id'],
   external_id: state.data['survey_info/household_id'],
-});
+}); */
 
-upsert('tbl_household_char', '', {
+/* insert('tbl_household_char', {
   site_id: 1001,
   study_id: 1000,
   household_id: state.data['survey_info/household_id'],
@@ -29,9 +29,9 @@ upsert('tbl_household_char', '', {
   num_pregnant_women: state.data['group_begin/group_people/nb_pregnant'],
   num_breastfeeding_women:
     state.data['group_begin/group_people/nb_brestfeeding'],
-});
+}); */
 
-upsert('tbl_sample', 'sample_id', {
+/* upsert('tbl_sample', 'sample_id', {
   study_id: 1000,
   site_id: 1001,
   household_id: state.data['survey_info/household_id'],
@@ -72,16 +72,16 @@ insertMany('tbl_wildmeat', state =>
       consumption_frequency_unit: foodItem['group_begin/group_food/frequency'],
     };
   })
-);
+); */
 
-upsert('tbl_individual', '', {
+insert('tbl_individual', {
   site_id: 1001,
   study_id: 1000,
   household_id: state.data['survey_info/household_id'],
   external_id: state.data['survey_info/identity'],
 });
 
-upsert('swm_transaction', 'uuid', {
+/* upsert('swm_transaction', 'uuid', {
   uuid:
     state.data._id + state.data._submission_time + state.data._xform_id_string,
   date: Date.now(),
@@ -91,4 +91,4 @@ upsert('swm_transaction', 'uuid', {
   inserted_by: 'open_fn',
   data_type: 'consumption',
   instances: state.data,
-});
+}); */


### PR DESCRIPTION
We added an operation which take a string and search for all kobo's form that include that string in the form's name. See line 8 `.filter(resource => resource.name.includes('Rural Consumption'))` on `fetch_kobo_data.js`

Should we create jobs on a openfn project and link them to these files in github @aleksa-krolls?
If so, please confirm the project number on openfn.org and Taylor and I will do the needful.